### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Then run it:
 
 ```bash
 docker rm -f tgr
-docker run --it  --name tgr -p 5000:5000 -e CLIENT_ID="xxxxxxx" -e CLIENT_SECRET="xxxxxxxxxxxxxxx" -e DEBUG="True" tgr
+docker run -it  --name tgr -p 5000:5000 -e CLIENT_ID="xxxxxxx" -e CLIENT_SECRET="xxxxxxxxxxxxxxx" -e DEBUG="True" tgr
 ```
 
 


### PR DESCRIPTION
fix docker run arg typo: --it is not valid. 
Needs to be -it or --interactive --tty
using shorter version