### PR TITLE
Fix flag on docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Then run it:
 
 ```bash
 docker rm -f tgr
-docker run --it  --name tgr -p 5000:5000 -e CLIENT_ID="xxxxxxx" -e CLIENT_SECRET="xxxxxxxxxxxxxxx" -e DEBUG="True" tgr
+docker run -it  --name tgr -p 5000:5000 -e CLIENT_ID="xxxxxxx" -e CLIENT_SECRET="xxxxxxxxxxxxxxx" -e DEBUG="True" tgr
 ```
 
 


### PR DESCRIPTION
There was two hyphens proceeding `it` in a docker run command rather than one. This doesn't work.